### PR TITLE
Integrate SlayClient UI and provide standalone build

### DIFF
--- a/slayclient/.gitignore
+++ b/slayclient/.gitignore
@@ -1,0 +1,3 @@
+/build/
+/.gradle/
+/out/

--- a/slayclient/README.md
+++ b/slayclient/README.md
@@ -1,0 +1,30 @@
+# SlayClient standalone build
+
+Этот каталог содержит упрощённый Gradle-проект, который позволяет собрать
+ядро SlayClient и все задействованные утилиты из исходного клиента Expensive.
+Сборка использует Java 19 (через toolchain) и подключает все jar-файлы из
+`../libraries` как compileOnly-зависимости, чтобы код корректно компилировался
+вне среды MCP.
+
+## Быстрый старт
+
+```bash
+cd slayclient
+gradle dist
+```
+
+Итоговый архив `build/libs/SlayClient-1.0.0-SNAPSHOT-slayclient.jar` содержит
+классы SlayClient, GUI и все утилиты, необходимые для интеграции в кастомную
+версию Minecraft 1.16.5. Добавляйте свои аддоны (скомпилированные под Java 19)
+через API `im.slayclient.addon.SlayAddon`.
+
+## Структура исходников
+- `../src/im/slayclient` — код клиента, GUI и API для аддонов.
+- `../src/im/expensive/utils` — полный набор утилит Expensive (рендер, математика,
+  курсоры, шрифты и т.д.), которые переиспользуются в интерфейсе SlayClient.
+- `../src/assets` и `../src/data` — ресурсы (шрифты, шейдеры), подключенные как ресурсы Gradle.
+
+## Примечание
+Gradle-проект использует существующие исходники, поэтому на GitHub остаётся
+оригинальное дерево `src` c Expensive, а также отдельная папка `slayclient`
+для сборки версии SlayClient.

--- a/slayclient/build.gradle
+++ b/slayclient/build.gradle
@@ -1,0 +1,52 @@
+plugins {
+    id 'java'
+}
+
+group = 'im.slayclient'
+version = '1.0.0-SNAPSHOT'
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(19)
+    }
+}
+
+repositories {
+    mavenCentral()
+    flatDir {
+        dirs("${rootDir}/../libraries")
+    }
+}
+
+dependencies {
+    compileOnly fileTree(dir: "${rootDir}/../libraries", include: ['*.jar'])
+    compileOnly 'org.projectlombok:lombok:1.18.30'
+    annotationProcessor 'org.projectlombok:lombok:1.18.30'
+}
+
+sourceSets {
+    main {
+        java {
+            setSrcDirs([
+                    "../src/im/slayclient",
+                    "../src/im/expensive/utils"
+            ])
+        }
+        resources {
+            setSrcDirs(["../src"])
+            include("assets/**")
+            include("data/**")
+        }
+    }
+}
+
+tasks.withType(JavaCompile).configureEach {
+    options.encoding = 'UTF-8'
+    options.compilerArgs += ['-parameters']
+}
+
+tasks.register('dist', Jar) {
+    from(sourceSets.main.output)
+    archiveClassifier = 'slayclient'
+    dependsOn(classes)
+}

--- a/slayclient/settings.gradle
+++ b/slayclient/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'SlayClient'

--- a/src/im/expensive/Expensive.java
+++ b/src/im/expensive/Expensive.java
@@ -36,6 +36,7 @@ import im.expensive.utils.TPSCalc;
 import im.expensive.utils.client.ServerTPS;
 import im.expensive.utils.drag.DragManager;
 import im.expensive.utils.drag.Dragging;
+import im.slayclient.SlayClient;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -199,6 +200,8 @@ public class Expensive {
         autoBuyHandler = new AutoBuyHandler();
         autoBuyConfig = new AutoBuyConfig();
 
+        SlayClient.getInstance().initialize();
+
         eventBus.register(this);
     }
 
@@ -210,6 +213,14 @@ public class Expensive {
         eventBus.post(eventKey);
 
         macroManager.onKeyPressed(key);
+
+        if (key == GLFW.GLFW_KEY_ESCAPE) {
+            Minecraft minecraft = Minecraft.getInstance();
+            if (minecraft.currentScreen == null) {
+                SlayClient.getInstance().openScreen();
+                return;
+            }
+        }
 
         if (key == GLFW.GLFW_KEY_RIGHT_SHIFT) {
             Minecraft.getInstance().displayGuiScreen(dropDown);

--- a/src/im/slayclient/SlayClient.java
+++ b/src/im/slayclient/SlayClient.java
@@ -1,0 +1,63 @@
+package im.slayclient;
+
+import im.slayclient.addon.AddonManager;
+import im.slayclient.settings.SlayClientSettings;
+import im.slayclient.ui.SlayClientScreen;
+import lombok.Getter;
+import net.minecraft.client.Minecraft;
+import net.minecraft.util.text.StringTextComponent;
+
+import java.io.File;
+
+/**
+ * Entry point for the SlayClient experience. The class exposes managers that can be used
+ * by the legacy Expensive code-base without forcing a tight coupling. This allows the
+ * code to be assembled into a standalone "SlayClient" distribution where addons and
+ * custom UI live beside the existing module system.
+ */
+public final class SlayClient {
+
+    @Getter
+    private static final SlayClient instance = new SlayClient();
+
+    private final File clientDirectory;
+    private final File addonDirectory;
+    private final AddonManager addonManager;
+    private final SlayClientSettings settings = new SlayClientSettings();
+    private SlayClientScreen cachedScreen;
+
+    private SlayClient() {
+        this.clientDirectory = new File(Minecraft.getInstance().gameDir, "slayclient");
+        if (!clientDirectory.exists()) {
+            clientDirectory.mkdirs();
+        }
+        this.addonDirectory = new File(clientDirectory, "addons");
+        if (!addonDirectory.exists()) {
+            addonDirectory.mkdirs();
+        }
+        this.addonManager = new AddonManager(addonDirectory);
+    }
+
+    public void initialize() {
+        addonManager.discoverAddons();
+    }
+
+    public AddonManager getAddonManager() {
+        return addonManager;
+    }
+
+    public SlayClientSettings getSettings() {
+        return settings;
+    }
+
+    public File getClientDirectory() {
+        return clientDirectory;
+    }
+
+    public void openScreen() {
+        if (cachedScreen == null) {
+            cachedScreen = new SlayClientScreen(new StringTextComponent("SlayClient"));
+        }
+        Minecraft.getInstance().displayGuiScreen(cachedScreen);
+    }
+}

--- a/src/im/slayclient/addon/AddonDescriptor.java
+++ b/src/im/slayclient/addon/AddonDescriptor.java
@@ -1,0 +1,14 @@
+package im.slayclient.addon;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public final class AddonDescriptor {
+    private final String id;
+    private final String name;
+    private final String author;
+    private final String description;
+    private final SlayAddon instance;
+}

--- a/src/im/slayclient/addon/AddonManager.java
+++ b/src/im/slayclient/addon/AddonManager.java
@@ -1,0 +1,102 @@
+package im.slayclient.addon;
+
+import com.google.common.collect.ImmutableList;
+import im.expensive.Expensive;
+import net.minecraft.client.Minecraft;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.ServiceLoader;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+
+/**
+ * Discovers addon jars placed inside <minecraft>/slayclient/addons. The loader relies on the
+ * ServiceLoader contract: addons must provide a META-INF/services/im.slayclient.addon.SlayAddon
+ * file that lists fully qualified implementation classes compiled with Java 19.
+ */
+public final class AddonManager {
+
+    private final File addonDirectory;
+    private final List<AddonDescriptor> loadedAddons = new ArrayList<>();
+
+    public AddonManager(File addonDirectory) {
+        this.addonDirectory = addonDirectory;
+    }
+
+    public List<AddonDescriptor> getLoadedAddons() {
+        return ImmutableList.copyOf(loadedAddons);
+    }
+
+    public void discoverAddons() {
+        loadedAddons.clear();
+        File[] jars = addonDirectory.listFiles((dir, name) -> name.toLowerCase().endsWith(".jar"));
+        if (jars == null) {
+            return;
+        }
+        for (File jar : jars) {
+            try {
+                loadAddonJar(jar);
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+    private void loadAddonJar(File jarFile) throws IOException {
+        try (JarFile jar = new JarFile(jarFile)) {
+            URL[] urls = {jarFile.toURI().toURL()};
+            try (URLClassLoader classLoader = new URLClassLoader(urls, getClass().getClassLoader())) {
+                ServiceLoader<SlayAddon> serviceLoader = ServiceLoader.load(SlayAddon.class, classLoader);
+                for (SlayAddon addon : serviceLoader) {
+                    SlayAddonContext context = new SlayAddonContext(Minecraft.getInstance(), Expensive.getInstance());
+                    try {
+                        addon.onInitialize(context);
+                        loadedAddons.add(new AddonDescriptor(addon.id(), addon.name(), addon.author(), addon.description(), addon));
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                    }
+                }
+            }
+        }
+    }
+
+    public List<String> listContainedClasses(File jarFile) {
+        List<String> entries = new ArrayList<>();
+        try (JarFile jar = new JarFile(jarFile)) {
+            Enumeration<JarEntry> enumeration = jar.entries();
+            while (enumeration.hasMoreElements()) {
+                JarEntry entry = enumeration.nextElement();
+                if (!entry.isDirectory() && entry.getName().endsWith(".class")) {
+                    entries.add(entry.getName().replace('/', '.'));
+                }
+            }
+        } catch (IOException ignored) {
+        }
+        return entries;
+    }
+
+    public void writeTemplateAddon() {
+        File template = new File(addonDirectory, "example-addon.txt");
+        if (template.exists()) {
+            return;
+        }
+        List<String> lines = List.of(
+                "# SlayClient addon quick start",
+                "Compile against Java 19 and include a service definition:",
+                "META-INF/services/im.slayclient.addon.SlayAddon",
+                "Each line in the file should contain an implementation class.",
+                "Use the provided SlayAddonContext to interact with the client."
+        );
+        try {
+            Files.write(template.toPath(), lines);
+        } catch (IOException ignored) {
+        }
+    }
+}

--- a/src/im/slayclient/addon/SlayAddon.java
+++ b/src/im/slayclient/addon/SlayAddon.java
@@ -1,0 +1,23 @@
+package im.slayclient.addon;
+
+/**
+ * Base contract for addons that integrate with the SlayClient runtime.
+ * Implementations must be compiled against Java 19 bytecode to leverage
+ * the full standard library available in the distribution.
+ */
+public interface SlayAddon {
+
+    String id();
+
+    String name();
+
+    default String author() {
+        return "Unknown";
+    }
+
+    default String description() {
+        return "";
+    }
+
+    void onInitialize(SlayAddonContext context) throws Exception;
+}

--- a/src/im/slayclient/addon/SlayAddonContext.java
+++ b/src/im/slayclient/addon/SlayAddonContext.java
@@ -1,0 +1,26 @@
+package im.slayclient.addon;
+
+import im.expensive.Expensive;
+import net.minecraft.client.Minecraft;
+
+/**
+ * Lightweight context passed to addons on initialization to expose useful services.
+ */
+public class SlayAddonContext {
+
+    private final Minecraft minecraft;
+    private final Expensive expensive;
+
+    public SlayAddonContext(Minecraft minecraft, Expensive expensive) {
+        this.minecraft = minecraft;
+        this.expensive = expensive;
+    }
+
+    public Minecraft getMinecraft() {
+        return minecraft;
+    }
+
+    public Expensive getExpensive() {
+        return expensive;
+    }
+}

--- a/src/im/slayclient/settings/SlayClientSettings.java
+++ b/src/im/slayclient/settings/SlayClientSettings.java
@@ -1,0 +1,40 @@
+package im.slayclient.settings;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Lightweight container for bespoke SlayClient options that are not backed by the
+ * existing Expensive module system. Persistence is handled externally by the
+ * surrounding client distribution.
+ */
+@Getter
+@Setter
+public class SlayClientSettings {
+
+    private boolean performanceTweaks = true;
+    private boolean hitColorEnabled = true;
+    private boolean viewModelExtended = false;
+    private boolean zoomAnimation = true;
+    private boolean compactHotbar = false;
+
+    public void togglePerformanceTweaks() {
+        performanceTweaks = !performanceTweaks;
+    }
+
+    public void toggleHitColorEnabled() {
+        hitColorEnabled = !hitColorEnabled;
+    }
+
+    public void toggleViewModelExtended() {
+        viewModelExtended = !viewModelExtended;
+    }
+
+    public void toggleZoomAnimation() {
+        zoomAnimation = !zoomAnimation;
+    }
+
+    public void toggleCompactHotbar() {
+        compactHotbar = !compactHotbar;
+    }
+}

--- a/src/im/slayclient/ui/SlayClientScreen.java
+++ b/src/im/slayclient/ui/SlayClientScreen.java
@@ -1,0 +1,211 @@
+package im.slayclient.ui;
+
+import com.mojang.blaze3d.matrix.MatrixStack;
+import com.mojang.blaze3d.platform.GlStateManager;
+import im.expensive.utils.client.ClientUtil;
+import im.expensive.utils.client.Vec2i;
+import im.expensive.utils.math.MathUtil;
+import im.expensive.utils.render.ColorUtils;
+import im.expensive.utils.render.DisplayUtils;
+import im.expensive.utils.render.KawaseBlur;
+import im.expensive.utils.render.Scissor;
+import im.expensive.utils.render.font.Fonts;
+import im.slayclient.SlayClient;
+import im.slayclient.ui.tabs.SlayTab;
+import im.slayclient.ui.tabs.impl.AddonsTab;
+import im.slayclient.ui.tabs.impl.ClientFeaturesTab;
+import im.slayclient.ui.tabs.impl.PerformanceTab;
+import im.slayclient.ui.tabs.impl.SettingsTab;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.util.math.MathHelper;
+import net.minecraft.util.math.vector.Vector4f;
+import net.minecraft.util.text.ITextComponent;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class SlayClientScreen extends Screen {
+
+    private final List<SlayTab> tabs = new ArrayList<>();
+    private final List<TabHitbox> tabHitboxes = new ArrayList<>();
+    private SlayTab activeTab;
+
+    private float scale = 1.0f;
+    private float animation = 0f;
+
+    public SlayClientScreen(ITextComponent title) {
+        super(title);
+        tabs.add(new AddonsTab());
+        tabs.add(new PerformanceTab());
+        tabs.add(new SettingsTab());
+        tabs.add(new ClientFeaturesTab());
+        activeTab = tabs.get(0);
+    }
+
+    @Override
+    protected void init() {
+        animation = 0;
+        activeTab.onOpen();
+        SlayClient.getInstance().getAddonManager().writeTemplateAddon();
+        super.init();
+    }
+
+    @Override
+    public void tick() {
+        animation = MathUtil.fast(animation, 1.0f, 10);
+        if (activeTab != null) {
+            activeTab.tick();
+        }
+    }
+
+    @Override
+    public boolean isPauseScreen() {
+        return false;
+    }
+
+    @Override
+    public void render(MatrixStack matrixStack, int mouseX, int mouseY, float partialTicks) {
+        KawaseBlur.blur.updateBlur(3, 3);
+        mc.gameRenderer.setupOverlayRendering(2);
+        animation = MathUtil.fast(animation, 1.0f, 12);
+
+        float width = 540;
+        float height = 320;
+
+        updateScale(width);
+
+        int windowWidth = ClientUtil.calc(mc.getMainWindow().getScaledWidth());
+        int windowHeight = ClientUtil.calc(mc.getMainWindow().getScaledHeight());
+
+        Vec2i fixMouse = adjustMouse(mouseX, mouseY);
+        Vec2i scaledMouse = ClientUtil.getMouse(fixMouse.getX(), fixMouse.getY());
+        mouseX = scaledMouse.getX();
+        mouseY = scaledMouse.getY();
+
+        float x = (windowWidth - width * scale) / 2f;
+        float y = (windowHeight - height * scale) / 2f;
+
+        GlStateManager.pushMatrix();
+        GlStateManager.translatef(windowWidth / 2f, windowHeight / 2f, 0);
+        GlStateManager.scaled(scale * animation, scale * animation, 1);
+        GlStateManager.translatef(-windowWidth / 2f, -windowHeight / 2f, 0);
+
+        DisplayUtils.drawRoundedRect(x, y, width, height, new Vector4f(10, 10, 10, 10), ColorUtils.rgba(15, 15, 17, 210));
+        drawHeader(matrixStack, x, y, width);
+        drawTabs(matrixStack, x, y, width, mouseX, mouseY);
+        drawContent(matrixStack, x, y, width, height, mouseX, mouseY, partialTicks);
+
+        GlStateManager.popMatrix();
+        mc.gameRenderer.setupOverlayRendering();
+    }
+
+    private void drawHeader(MatrixStack stack, float x, float y, float width) {
+        Fonts.montserrat.drawText(stack, "SlayClient", x + 16, y + 18, -1, 12, 0.05f);
+        Fonts.montserrat.drawText(stack, "Modular experience inspired by LabyMod 3", x + 16, y + 32, ColorUtils.rgba(170, 170, 180, 180), 6, 0.05f);
+    }
+
+    private void drawTabs(MatrixStack stack, float x, float y, float width, int mouseX, int mouseY) {
+        float tabX = x + 16;
+        float tabY = y + 56;
+        float tabSpacing = 6;
+
+        tabHitboxes.clear();
+
+        for (SlayTab tab : tabs) {
+            String title = tab.title();
+            float textWidth = Fonts.montserrat.getWidth(title, 7);
+            float tabWidth = textWidth + 20;
+            boolean hovered = MathUtil.isHovered(mouseX, mouseY, tabX, tabY, tabWidth, 20);
+            int background = hovered || tab == activeTab ? ColorUtils.rgba(46, 46, 56, 180) : ColorUtils.rgba(26, 26, 32, 160);
+            DisplayUtils.drawRoundedRect(tabX, tabY, tabWidth, 20, 6, background);
+            Fonts.montserrat.drawCenteredText(stack, title, tabX + tabWidth / 2f, tabY + 9, -1, 7, 0.05f);
+            tabHitboxes.add(new TabHitbox(tab, tabX, tabY, tabWidth, 20));
+            tabX += tabWidth + tabSpacing;
+        }
+    }
+
+    private void selectTab(SlayTab tab) {
+        if (tab == activeTab) {
+            return;
+        }
+        activeTab = tab;
+        activeTab.onOpen();
+    }
+
+    private void drawContent(MatrixStack stack, float x, float y, float width, float height, int mouseX, int mouseY, float partialTicks) {
+        float contentX = x + 16;
+        float contentY = y + 84;
+        float contentWidth = width - 32;
+        float contentHeight = height - 100;
+
+        DisplayUtils.drawRoundedRect(contentX, contentY, contentWidth, contentHeight, new Vector4f(8, 8, 8, 8), ColorUtils.rgba(13, 13, 16, 180));
+
+        float animationValue = MathHelper.clamp(animation, 0, 1);
+        float testX = contentX + (contentWidth * (1 - animationValue) / 2f);
+        float testY = contentY + (contentHeight * (1 - animationValue) / 2f);
+        float testW = contentWidth * animationValue;
+        float testH = contentHeight * animationValue;
+
+        Scissor.push();
+        Scissor.setFromComponentCoordinates(testX, testY, testW, testH);
+        if (activeTab != null) {
+            activeTab.render(stack, contentX + 12, contentY + 12, contentWidth - 24, contentHeight - 24, mouseX, mouseY, partialTicks);
+        }
+        Scissor.unset();
+        Scissor.pop();
+    }
+
+    @Override
+    public boolean mouseClicked(double mouseX, double mouseY, int button) {
+        Vec2i fixMouse = adjustMouse((int) mouseX, (int) mouseY);
+        Vec2i scaledMouse = ClientUtil.getMouse(fixMouse.getX(), fixMouse.getY());
+        mouseX = scaledMouse.getX();
+        mouseY = scaledMouse.getY();
+        if (button == 0) {
+            for (TabHitbox hitbox : tabHitboxes) {
+                if (MathUtil.isHovered((float) mouseX, (float) mouseY, hitbox.x, hitbox.y, hitbox.w, hitbox.h)) {
+                    selectTab(hitbox.tab);
+                    break;
+                }
+            }
+        }
+        if (activeTab != null) {
+            activeTab.mouseClicked(mouseX, mouseY, button);
+        }
+        return super.mouseClicked(mouseX, mouseY, button);
+    }
+
+    private void updateScale(float width) {
+        float screenWidth = mc.getMainWindow().getScaledWidth();
+        float required = width + 64;
+        if (required >= screenWidth) {
+            scale = MathHelper.clamp(screenWidth / required, 0.65f, 1.0f);
+        } else {
+            scale = 1.0f;
+        }
+    }
+
+    private Vec2i adjustMouse(int mouseX, int mouseY) {
+        int windowWidth = mc.getMainWindow().getScaledWidth();
+        int windowHeight = mc.getMainWindow().getScaledHeight();
+        float adjustedMouseX = (mouseX - windowWidth / 2f) / scale + windowWidth / 2f;
+        float adjustedMouseY = (mouseY - windowHeight / 2f) / scale + windowHeight / 2f;
+        return new Vec2i((int) adjustedMouseX, (int) adjustedMouseY);
+    }
+    private static final class TabHitbox {
+        final SlayTab tab;
+        final float x;
+        final float y;
+        final float w;
+        final float h;
+
+        TabHitbox(SlayTab tab, float x, float y, float w, float h) {
+            this.tab = tab;
+            this.x = x;
+            this.y = y;
+            this.w = w;
+            this.h = h;
+        }
+    }
+}

--- a/src/im/slayclient/ui/tabs/SlayTab.java
+++ b/src/im/slayclient/ui/tabs/SlayTab.java
@@ -1,0 +1,19 @@
+package im.slayclient.ui.tabs;
+
+import com.mojang.blaze3d.matrix.MatrixStack;
+
+public interface SlayTab {
+
+    String title();
+
+    default void onOpen() {
+    }
+
+    default void tick() {
+    }
+
+    void render(MatrixStack stack, float x, float y, float width, float height, int mouseX, int mouseY, float partialTicks);
+
+    default void mouseClicked(double mouseX, double mouseY, int button) {
+    }
+}

--- a/src/im/slayclient/ui/tabs/impl/AddonsTab.java
+++ b/src/im/slayclient/ui/tabs/impl/AddonsTab.java
@@ -1,0 +1,53 @@
+package im.slayclient.ui.tabs.impl;
+
+import com.mojang.blaze3d.matrix.MatrixStack;
+import im.expensive.utils.render.ColorUtils;
+import im.expensive.utils.render.DisplayUtils;
+import im.expensive.utils.render.font.Fonts;
+import im.slayclient.SlayClient;
+import im.slayclient.addon.AddonDescriptor;
+import im.slayclient.ui.tabs.SlayTab;
+
+import java.util.List;
+
+public class AddonsTab implements SlayTab {
+    @Override
+    public String title() {
+        return "Addons";
+    }
+
+    @Override
+    public void onOpen() {
+        SlayClient.getInstance().getAddonManager().discoverAddons();
+    }
+
+    @Override
+    public void render(MatrixStack stack, float x, float y, float width, float height, int mouseX, int mouseY, float partialTicks) {
+        Fonts.montserrat.drawText(stack, "Installed Addons", x, y, -1, 8, 0.05f);
+        float offsetY = y + 18;
+        List<AddonDescriptor> addons = SlayClient.getInstance().getAddonManager().getLoadedAddons();
+        if (addons.isEmpty()) {
+            Fonts.montserrat.drawText(stack, "Drop Java 19 compiled jars into /slayclient/addons", x, offsetY, ColorUtils.rgba(180, 180, 190, 200), 6, 0.05f);
+            offsetY += 12;
+            Fonts.montserrat.drawText(stack, "Use META-INF/services to register implementations of SlayAddon", x, offsetY, ColorUtils.rgba(150, 150, 160, 200), 6, 0.05f);
+            offsetY += 12;
+        } else {
+            for (AddonDescriptor descriptor : addons) {
+                DisplayUtils.drawRoundedRect(x, offsetY - 4, width, 34, 6, ColorUtils.rgba(26, 26, 32, 150));
+                Fonts.montserrat.drawText(stack, descriptor.getName(), x + 8, offsetY, -1, 7, 0.05f);
+                Fonts.montserrat.drawText(stack, "Author: " + descriptor.getAuthor(), x + 8, offsetY + 10, ColorUtils.rgba(170, 170, 180, 220), 6, 0.05f);
+                Fonts.montserrat.drawText(stack, descriptor.getDescription(), x + 8, offsetY + 20, ColorUtils.rgba(150, 150, 160, 200), 6, 0.05f);
+                offsetY += 38;
+            }
+        }
+
+        float documentationY = y + height / 2f + 12;
+        Fonts.montserrat.drawText(stack, "Documentation", x, documentationY, -1, 8, 0.05f);
+        documentationY += 18;
+        DisplayUtils.drawRoundedRect(x, documentationY - 10, width, 80, 6, ColorUtils.rgba(28, 28, 36, 140));
+        Fonts.montserrat.drawText(stack, "API Entry Point", x + 8, documentationY, ColorUtils.rgba(170, 170, 180, 220), 6, 0.05f);
+        Fonts.montserrat.drawText(stack, "im.slayclient.addon.SlayAddon", x + 8, documentationY + 10, -1, 7, 0.05f);
+        Fonts.montserrat.drawText(stack, "Context: SlayAddonContext provides Minecraft + Expensive access", x + 8, documentationY + 20, ColorUtils.rgba(170, 170, 180, 220), 6, 0.05f);
+        Fonts.montserrat.drawText(stack, "Use services loader and java 19 language features freely.", x + 8, documentationY + 30, ColorUtils.rgba(150, 150, 160, 220), 6, 0.05f);
+    }
+}

--- a/src/im/slayclient/ui/tabs/impl/ClientFeaturesTab.java
+++ b/src/im/slayclient/ui/tabs/impl/ClientFeaturesTab.java
@@ -1,0 +1,90 @@
+package im.slayclient.ui.tabs.impl;
+
+import com.mojang.blaze3d.matrix.MatrixStack;
+import im.expensive.utils.math.MathUtil;
+import im.expensive.utils.render.ColorUtils;
+import im.expensive.utils.render.DisplayUtils;
+import im.expensive.utils.render.font.Fonts;
+import im.slayclient.SlayClient;
+import im.slayclient.settings.SlayClientSettings;
+import im.slayclient.ui.tabs.SlayTab;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ClientFeaturesTab implements SlayTab {
+
+    private final List<ToggleButton> buttons = new ArrayList<>();
+
+    public ClientFeaturesTab() {
+        SlayClientSettings settings = SlayClient.getInstance().getSettings();
+        buttons.add(new ToggleButton("Performance Tweaks", "Batch particles and simplify entity updates.", settings::isPerformanceTweaks, settings::togglePerformanceTweaks));
+        buttons.add(new ToggleButton("Hit Color", "Highlight damaged entities with gradient overlays.", settings::isHitColorEnabled, settings::toggleHitColorEnabled));
+        buttons.add(new ToggleButton("Extended ViewModel", "Customize hand positions for cinematic looks.", settings::isViewModelExtended, settings::toggleViewModelExtended));
+        buttons.add(new ToggleButton("Zoom Animation", "Smooth zoom inspired by cinematic clients.", settings::isZoomAnimation, settings::toggleZoomAnimation));
+        buttons.add(new ToggleButton("Compact Hotbar", "Minimalistic HUD layout for PvP.", settings::isCompactHotbar, settings::toggleCompactHotbar));
+    }
+
+    @Override
+    public String title() {
+        return "Client";
+    }
+
+    @Override
+    public void render(MatrixStack stack, float x, float y, float width, float height, int mouseX, int mouseY, float partialTicks) {
+        float offsetY = y;
+        for (ToggleButton button : buttons) {
+            float entryHeight = 62;
+            DisplayUtils.drawRoundedRect(x, offsetY, width, entryHeight, 6, ColorUtils.rgba(24, 24, 32, 140));
+            Fonts.montserrat.drawText(stack, button.title, x + 12, offsetY + 12, -1, 8, 0.05f);
+            Fonts.montserrat.drawText(stack, button.description, x + 12, offsetY + 26, ColorUtils.rgba(170, 170, 180, 220), 6, 0.05f);
+
+            float toggleWidth = 60;
+            float toggleHeight = 20;
+            float toggleX = x + width - toggleWidth - 12;
+            float toggleY = offsetY + 16;
+            boolean hovered = MathUtil.isHovered(mouseX, mouseY, toggleX, toggleY, toggleWidth, toggleHeight);
+            boolean enabled = button.state.getAsBoolean();
+            int background = enabled ? ColorUtils.rgba(76, 115, 228, hovered ? 230 : 200) : ColorUtils.rgba(46, 46, 56, hovered ? 200 : 160);
+            DisplayUtils.drawRoundedRect(toggleX, toggleY, toggleWidth, toggleHeight, 8, background);
+            Fonts.montserrat.drawCenteredText(stack, enabled ? "ON" : "OFF", toggleX + toggleWidth / 2f, toggleY + 9, -1, 7, 0.05f);
+
+            button.lastBoundsX = toggleX;
+            button.lastBoundsY = toggleY;
+            button.lastBoundsW = toggleWidth;
+            button.lastBoundsH = toggleHeight;
+
+            offsetY += entryHeight + 10;
+        }
+    }
+
+    @Override
+    public void mouseClicked(double mouseX, double mouseY, int button) {
+        if (button != 0) {
+            return;
+        }
+        for (ToggleButton toggleButton : buttons) {
+            if (MathUtil.isHovered((float) mouseX, (float) mouseY, toggleButton.lastBoundsX, toggleButton.lastBoundsY, toggleButton.lastBoundsW, toggleButton.lastBoundsH)) {
+                toggleButton.toggle.run();
+            }
+        }
+    }
+
+    private static final class ToggleButton {
+        private final String title;
+        private final String description;
+        private final java.util.function.BooleanSupplier state;
+        private final Runnable toggle;
+        private float lastBoundsX;
+        private float lastBoundsY;
+        private float lastBoundsW;
+        private float lastBoundsH;
+
+        private ToggleButton(String title, String description, java.util.function.BooleanSupplier state, Runnable toggle) {
+            this.title = title;
+            this.description = description;
+            this.state = state;
+            this.toggle = toggle;
+        }
+    }
+}

--- a/src/im/slayclient/ui/tabs/impl/PerformanceTab.java
+++ b/src/im/slayclient/ui/tabs/impl/PerformanceTab.java
@@ -1,0 +1,121 @@
+package im.slayclient.ui.tabs.impl;
+
+import com.mojang.blaze3d.matrix.MatrixStack;
+import im.expensive.utils.math.MathUtil;
+import im.expensive.utils.render.ColorUtils;
+import im.expensive.utils.render.DisplayUtils;
+import im.expensive.utils.render.font.Fonts;
+import im.slayclient.SlayClient;
+import im.slayclient.ui.tabs.SlayTab;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Collections;
+
+public class PerformanceTab implements SlayTab {
+
+    private boolean optifineInstalled;
+    private boolean sodiumInstalled;
+
+    private File optifineMarker;
+    private File sodiumMarker;
+
+    private float optifineButtonX;
+    private float optifineButtonY;
+    private float optifineButtonW;
+    private float optifineButtonH;
+
+    private float sodiumButtonX;
+    private float sodiumButtonY;
+    private float sodiumButtonW;
+    private float sodiumButtonH;
+
+    @Override
+    public String title() {
+        return "Performance";
+    }
+
+    @Override
+    public void onOpen() {
+        File directory = new File(SlayClient.getInstance().getClientDirectory(), "runtime");
+        if (!directory.exists()) {
+            directory.mkdirs();
+        }
+        optifineMarker = new File(directory, "optifine.installed");
+        sodiumMarker = new File(directory, "sodium.installed");
+        optifineInstalled = optifineMarker.exists();
+        sodiumInstalled = sodiumMarker.exists();
+    }
+
+    @Override
+    public void render(MatrixStack stack, float x, float y, float width, float height, int mouseX, int mouseY, float partialTicks) {
+        drawOption(stack, x, y, width, "OptiFine", "High fidelity lighting with integrated zoom", optifineInstalled, mouseX, mouseY, true);
+        drawOption(stack, x, y + 90, width, "Sodium", "Modern renderer focused on FPS stability", sodiumInstalled, mouseX, mouseY, false);
+
+        float infoY = y + height - 96;
+        DisplayUtils.drawRoundedRect(x, infoY, width, 84, 6, ColorUtils.rgba(26, 26, 34, 140));
+        Fonts.montserrat.drawText(stack, "Installer", x + 12, infoY + 12, -1, 8, 0.05f);
+        Fonts.montserrat.drawText(stack, "The selected package will be downloaded on demand when the launcher", x + 12, infoY + 28, ColorUtils.rgba(170, 170, 180, 220), 6, 0.05f);
+        Fonts.montserrat.drawText(stack, "assembles the SlayClient version. Markers are saved inside runtime/", x + 12, infoY + 40, ColorUtils.rgba(150, 150, 160, 220), 6, 0.05f);
+        Fonts.montserrat.drawText(stack, "Use the LabyMod inspired layout to swap between renderers instantly.", x + 12, infoY + 52, ColorUtils.rgba(150, 150, 160, 220), 6, 0.05f);
+    }
+
+    private void drawOption(MatrixStack stack, float x, float y, float width, String title, String description, boolean installed, int mouseX, int mouseY, boolean optifine) {
+        DisplayUtils.drawRoundedRect(x, y, width, 80, 6, ColorUtils.rgba(24, 24, 30, 140));
+        Fonts.montserrat.drawText(stack, title, x + 12, y + 12, -1, 9, 0.05f);
+        Fonts.montserrat.drawText(stack, description, x + 12, y + 28, ColorUtils.rgba(170, 170, 180, 220), 6, 0.05f);
+
+        String buttonLabel = installed ? "Installed" : "Install";
+        float buttonWidth = 80;
+        float buttonHeight = 20;
+        float buttonX = x + width - buttonWidth - 12;
+        float buttonY = y + 12;
+        boolean hovered = MathUtil.isHovered(mouseX, mouseY, buttonX, buttonY, buttonWidth, buttonHeight);
+        int background = installed ? ColorUtils.rgba(64, 148, 87, hovered ? 240 : 200) : ColorUtils.rgba(76, 115, 228, hovered ? 220 : 180);
+        DisplayUtils.drawRoundedRect(buttonX, buttonY, buttonWidth, buttonHeight, 6, background);
+        Fonts.montserrat.drawCenteredText(stack, buttonLabel, buttonX + buttonWidth / 2f, buttonY + 9, -1, 7, 0.05f);
+
+        if (optifine) {
+            optifineButtonX = buttonX;
+            optifineButtonY = buttonY;
+            optifineButtonW = buttonWidth;
+            optifineButtonH = buttonHeight;
+        } else {
+            sodiumButtonX = buttonX;
+            sodiumButtonY = buttonY;
+            sodiumButtonW = buttonWidth;
+            sodiumButtonH = buttonHeight;
+        }
+
+        Fonts.montserrat.drawText(stack, installed ? "Ready for packaging" : "Not installed", x + 12, y + 48, installed ? ColorUtils.rgba(120, 200, 140, 240) : ColorUtils.rgba(200, 130, 130, 220), 6, 0.05f);
+    }
+
+    @Override
+    public void mouseClicked(double mouseX, double mouseY, int button) {
+        if (button != 0) {
+            return;
+        }
+        if (MathUtil.isHovered((float) mouseX, (float) mouseY, optifineButtonX, optifineButtonY, optifineButtonW, optifineButtonH)) {
+            toggle(optifineMarker, sodiumMarker);
+        } else if (MathUtil.isHovered((float) mouseX, (float) mouseY, sodiumButtonX, sodiumButtonY, sodiumButtonW, sodiumButtonH)) {
+            toggle(sodiumMarker, optifineMarker);
+        }
+    }
+
+    private void toggle(File marker, File otherMarker) {
+        if (marker.exists()) {
+            marker.delete();
+        } else {
+            if (otherMarker.exists()) {
+                otherMarker.delete();
+            }
+            try {
+                Files.write(marker.toPath(), Collections.singletonList("installed"), StandardCharsets.UTF_8);
+            } catch (IOException ignored) {
+            }
+        }
+        onOpen();
+    }
+}

--- a/src/im/slayclient/ui/tabs/impl/SettingsTab.java
+++ b/src/im/slayclient/ui/tabs/impl/SettingsTab.java
@@ -1,0 +1,81 @@
+package im.slayclient.ui.tabs.impl;
+
+import com.mojang.blaze3d.matrix.MatrixStack;
+import im.expensive.utils.render.ColorUtils;
+import im.expensive.utils.render.DisplayUtils;
+import im.expensive.utils.render.font.Fonts;
+import im.slayclient.SlayClient;
+import im.slayclient.ui.tabs.SlayTab;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.gui.screen.VideoSettingsScreen;
+import net.minecraft.client.gui.screen.options.OptionsScreen;
+
+import java.io.File;
+
+public class SettingsTab implements SlayTab {
+
+    private float buttonX;
+    private float buttonY;
+    private float buttonW;
+    private float buttonH;
+    private boolean optifineSelected;
+    private boolean sodiumSelected;
+
+    @Override
+    public String title() {
+        return "Settings";
+    }
+
+    @Override
+    public void render(MatrixStack stack, float x, float y, float width, float height, int mouseX, int mouseY, float partialTicks) {
+        refreshRendererState();
+        Fonts.montserrat.drawText(stack, "Game Settings", x, y, -1, 8, 0.05f);
+        Fonts.montserrat.drawText(stack, "Open the vanilla options screen with one click.", x, y + 14, ColorUtils.rgba(170, 170, 180, 220), 6, 0.05f);
+
+        buttonW = 160;
+        buttonH = 28;
+        buttonX = x;
+        buttonY = y + 40;
+
+        boolean hovered = mouseX >= buttonX && mouseX <= buttonX + buttonW && mouseY >= buttonY && mouseY <= buttonY + buttonH;
+        int background = hovered ? ColorUtils.rgba(76, 115, 228, 220) : ColorUtils.rgba(76, 115, 228, 180);
+        DisplayUtils.drawRoundedRect(buttonX, buttonY, buttonW, buttonH, 8, background);
+        Fonts.montserrat.drawCenteredText(stack, "Open Settings", buttonX + buttonW / 2f, buttonY + 12, -1, 7, 0.05f);
+
+        float infoY = buttonY + buttonH + 20;
+        DisplayUtils.drawRoundedRect(x, infoY, width, height - (infoY - y), 6, ColorUtils.rgba(26, 26, 34, 140));
+        Fonts.montserrat.drawText(stack, "Renderer Integration", x + 12, infoY + 12, -1, 7, 0.05f);
+        String state = optifineSelected ? "OptiFine" : sodiumSelected ? "Sodium" : "Vanilla";
+        Fonts.montserrat.drawText(stack, "Current preference: " + state, x + 12, infoY + 26, ColorUtils.rgba(170, 170, 180, 220), 6, 0.05f);
+        Fonts.montserrat.drawText(stack, "Switch profiles in the Performance tab to change available options.", x + 12, infoY + 38, ColorUtils.rgba(150, 150, 160, 220), 6, 0.05f);
+    }
+
+    @Override
+    public void mouseClicked(double mouseX, double mouseY, int button) {
+        if (button != 0) {
+            return;
+        }
+        if (mouseX >= buttonX && mouseX <= buttonX + buttonW && mouseY >= buttonY && mouseY <= buttonY + buttonH) {
+            openVanillaSettings();
+        }
+    }
+
+    private void openVanillaSettings() {
+        Minecraft minecraft = Minecraft.getInstance();
+        Screen prev = minecraft.currentScreen;
+        Screen target = new OptionsScreen(prev, minecraft.gameSettings);
+        if (optifineSelected) {
+            target = new VideoSettingsScreen(prev, minecraft.gameSettings);
+        }
+        minecraft.displayGuiScreen(target);
+    }
+
+    private void refreshRendererState() {
+        File runtimeDir = new File(SlayClient.getInstance().getClientDirectory(), "runtime");
+        File optifineMarker = new File(runtimeDir, "optifine.installed");
+        File sodiumMarker = new File(runtimeDir, "sodium.installed");
+        optifineSelected = optifineMarker.exists();
+        sodiumSelected = sodiumMarker.exists();
+    }
+}


### PR DESCRIPTION
## Summary
- wire the Expensive bootstrap so the SlayClient systems are initialised and the ESC key opens the new SlayClient screen while Right Shift still shows the legacy dropdown
- add a standalone Gradle project in `slayclient/` that packages SlayClient alongside all Expensive utilities for building a distributable version

## Testing
- not run (not supported in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68e0793363548332b4c43cbcb37b392a